### PR TITLE
Add install instructions for python-requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,24 @@ Dependencies
 * python3 or python2 (http://python.org/)
 * python-requests or python2-requests (http://python-requests.org/)
 
+Installing python-requests
+==========================
+If you have root, Use pip, easy_install or apt to install requests
+```shell
+pip install requests
+easy_install requests
+apt-get install python-requests
+```
+
+If you do not have root, then install requests locally
+```shell
+curl -L https://github.com/kennethreitz/requests/tarball/master | tar xz
+cd kennethreitz-requests*
+python setup.py install --user
+cd ..
+rm -rf master kennethreitz-requests*
+```
+
 Notes
 =====
 * It's not possible to have streaming uploads with the requests module and d-h.


### PR DESCRIPTION
The biggest complaint about this script is that it uses python-requests,
which causes an issue for people who don't have root, and don't know how
to install a local python module.
Add install instructions for python-request to be installed in a local
directory.

The root install instructions are added for completeness.
